### PR TITLE
fix for bug with wrong bundle for getting xcdatamodel when using frameworks in cocoapods

### DIFF
--- a/Pod/Classes/APCDController.m
+++ b/Pod/Classes/APCDController.m
@@ -259,7 +259,7 @@ static APCDController *defaultController = nil;
 - (NSURL *)modelURL
 {
     NSString *modelPath = nil;
-    NSBundle *currentBundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *currentBundle = [NSBundle mainBundle];
     
     modelPath = [currentBundle pathForResource:_storeName ofType:kAPCDControllerModelMOMDExtension];
     if (!modelPath) {


### PR DESCRIPTION
When you install APCDController via Cocoapods with `use_frameworks!` in your podfile then `[NSBundle bundleForClass:[self class]];` returns framework's bundle and not main app's bundle as intended to be.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/deszip/apcdcontroller/5)

<!-- Reviewable:end -->
